### PR TITLE
fix getProjectUsers method

### DIFF
--- a/lib/api/projects.js
+++ b/lib/api/projects.js
@@ -92,7 +92,7 @@ TogglClient.prototype.getProjectTasks = function getProjectTasks(projectId,
  */
 TogglClient.prototype.getProjectUsers = function getProjectUsers(projectId,
   callback) {
-  this.apiRequest('/api/v8/projects/' + projectId + '/users', {}, callback);
+  this.apiRequest('/api/v8/projects/' + projectId + '/project_users', {}, callback);
 };
 
 


### PR DESCRIPTION
getProjectUsers method always returning 404. The reason is a url, which had to be `https://www.toggl.com/api/v8/projects/{project_id}/project_users` instead of `https://www.toggl.com/api/v8/projects/{project_id}/users`