### PR TITLE
Update API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 toggl-api
 ==========
 
-[Toggl](https://www.toggl.com/) API for Node.js. Library is based on official Toggl API [documentation](https://github.com/toggl/toggl_api_docs).
+[Toggl track](https://track.toggl.com/) API for Node.js. Library is based on official Toggl API [documentation](https://github.com/toggl/toggl_api_docs).
 
 ## Installation
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -13,7 +13,7 @@ var DEFAULT_INSTANCE = null;
 var DEFAULTS = {
   reauth: false,
   sessionCookie: 'toggl_api_session',
-  apiUrl: 'https://www.toggl.com',
+  apiUrl: 'https://track.toggl.com',
   reportsUrl: 'https://toggl.com/reports'
 };
 


### PR DESCRIPTION
Fix for issue #17 

According to [this branch](https://github.com/toggl/toggl_api_docs/tree/switch-to-api-track) it seems like the reports URL didn't need to be updated, but the track API one did.