### PR TITLE
Fix weird error bug with detailed report

### DIFF
--- a/lib/api/reports.js
+++ b/lib/api/reports.js
@@ -44,7 +44,7 @@ TogglClient.prototype.detailedReport = function detailedReport(opts, callback) {
     return;
   }
 
-  this.reportsRequest('/api/v2/details', { qs: opts }, callback);
+  this.reportsRequest('/details', { qs: opts }, callback);
 };
 
 


### PR DESCRIPTION
I encountered an issue when trying to use the detailed report function. I looked at the opts that was being passed to the request function and the url contained two "/api/v2"s on the end. Not sure if this is a bigger problem than this one function just know that this change makes the detailed report function work.