### PR TITLE
Remove version path from reportsUrl

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -14,7 +14,7 @@ var DEFAULTS = {
   reauth: false,
   sessionCookie: 'toggl_api_session',
   apiUrl: 'https://api.track.toggl.com',
-  reportsUrl: 'https://api.track.toggl.com/reports/api/v2'
+  reportsUrl: 'https://api.track.toggl.com/reports'
 };
 
 


### PR DESCRIPTION
This commit https://github.com/7eggs/node-toggl-api/commit/d396c1cda5d5f54fc132a24e79c94f1dc76aff33 broke the reports endpoints because the `/api/v2` is added with every `reportsRequest` call. This results in invalid calls to the reports API (404 not found)

![Screen Shot 2022-05-23 at 12 35 32 PM](https://user-images.githubusercontent.com/4914611/169801262-cb622715-03f3-4081-b740-3faba5be8f68.png)

